### PR TITLE
mwlwifi: A-MSDU inside A-MPDU is optional

### DIFF
--- a/mac80211.c
+++ b/mac80211.c
@@ -653,6 +653,8 @@ static int mwl_mac80211_ampdu_action(struct ieee80211_hw *hw,
 			}
 
 			mwl_fwcmd_remove_stream(hw, stream);
+			/* re-enable A-MSDU. See below */
+			sta_info->is_amsdu_allowed = true;
 		}
 
 		ieee80211_stop_tx_ba_cb_irqsafe(vif, addr, tid);
@@ -668,6 +670,12 @@ static int mwl_mac80211_ampdu_action(struct ieee80211_hw *hw,
 
 		if (!rc) {
 			stream->state = AMPDU_STREAM_ACTIVE;
+			/*  Support for A-MSDU within A-MPDU is
+			 *  optional.  Simply disable A-MSDU until we
+			 *  have a new API with the peer support
+			 *  status.
+			 */
+			sta_info->is_amsdu_allowed = false;
 		} else {
 			idx = stream->idx;
 			spin_unlock_bh(&priv->stream_lock);


### PR DESCRIPTION
This is intended as a temporary fix for issue #34 until the
mac80211 API is updated with the necessary information
from the ADDBA reponse. 

Stations not supporting this optional feature will not be able
to process A-MSDU frames when an A-MPDU stream is operational.
A-MSDU support is signalled in the ADDBA response, but not yet
forwarded to drivers.  Disable A-MSDU when A-MPDU is operational
for all stations until the API support selectively enabling it.

Signed-off-by: Bjørn Mork <bjorn@mork.no>