### PR TITLE
Fix for incorrect prefix on defition being passed to ieee80211_hw_set

### DIFF
--- a/main.c
+++ b/main.c
@@ -545,7 +545,7 @@ static int mwl_wl_init(struct mwl_priv *priv)
 		     IEEE80211_HW_MFP_CAPABLE;
 #else
 	ieee80211_hw_set(hw, SUPPORTS_PER_STA_GTK);
-	ieee80211_hw_set(hw, HW_MFP_CAPABLE);
+	ieee80211_hw_set(hw, MFP_CAPABLE);
 #endif
 
 	hw->wiphy->flags |= WIPHY_FLAG_IBSS_RSN;

--- a/rx.c
+++ b/rx.c
@@ -501,7 +501,6 @@ void mwl_rx_recv(unsigned long data)
 
 		priv->is_rx_schedule = false;
 		wiphy_warn(hw->wiphy, "busy or no receiving packets\n");
-		//spin_unlock(&priv->rx_desc_lock);
 		return;
 	}
 
@@ -631,5 +630,4 @@ out:
 
 	priv->is_rx_schedule = false;
 
-	//spin_unlock(&priv->rx_desc_lock);
 }


### PR DESCRIPTION
The ieee80211_hw_set macro appends the HW_ prefix to the argument already.
@tiremeat 's spinlock changes

