### PR TITLE
HDR : Added header file

### DIFF
--- a/core.c
+++ b/core.c
@@ -15,6 +15,8 @@
 
 /* Description:  This file implements core layer related functions. */
 
+#include <linux/etherdevice.h>
+
 #include "sysadpt.h"
 #include "core.h"
 #include "thermal.h"


### PR DESCRIPTION
I could not compile the latest master branch of mwlwifi on openwrt (latest master) without adding this header file. If not I get a `implicit declaration of ether_addr_copy`.

This addition fixes the error. 