### PR TITLE
Use kernel_write() instead of vfs_write() to fix compile on 4.14

### DIFF
--- a/debugfs.c
+++ b/debugfs.c
@@ -279,7 +279,6 @@ static void core_dump_file(u8 *valbuf, u32 length, u32 region, u32 address,
 			   u32 append, u32 totallen, bool textmode)
 {
 	struct file *filp_core = NULL;
-	mm_segment_t oldfs;
 	char file_name[40];
 	u8 *buf = kmalloc(length * 3, GFP_KERNEL);
 	u8 *data_p = buf;
@@ -291,9 +290,6 @@ static void core_dump_file(u8 *valbuf, u32 length, u32 region, u32 address,
 	memset(file_name, 0, sizeof(file_name));
 	sprintf(file_name, "/dev/shm/coredump-%x-%x",
 		region, (region + totallen));
-
-	oldfs = get_fs();
-	set_fs(KERNEL_DS);
 
 	if (append)
 		filp_core = filp_open(file_name, O_RDWR | O_APPEND, 0);
@@ -317,15 +313,15 @@ static void core_dump_file(u8 *valbuf, u32 length, u32 region, u32 address,
 			}
 			data_p = buf + j;
 			data_p += sprintf(data_p, "\n");
-			vfs_write(filp_core, buf, strlen(buf),
-				  &filp_core->f_pos);
+			kernel_write(filp_core, buf, strlen(buf),
+				     &filp_core->f_pos);
 		} else
-			vfs_write(filp_core, valbuf, length, &filp_core->f_pos);
+			kernel_write(filp_core, valbuf, length,
+				     &filp_core->f_pos);
 
 		filp_close(filp_core, current->files);
 	}
 
-	set_fs(oldfs);
 	kfree(buf);
 }
 
@@ -1338,7 +1334,6 @@ static ssize_t mwl_debugfs_ba_hist_read(struct file *file, char __user *ubuf,
 	u8 bmap0flag, nobaflag;
 	char buff[500], file_location[20];
 	struct file *filp_bahisto;
-	mm_segment_t oldfs;
 	u8 *data_p = buff;
 	ssize_t ret;
 
@@ -1354,13 +1349,10 @@ static ssize_t mwl_debugfs_ba_hist_read(struct file *file, char __user *ubuf,
 	memset(file_location, 0, sizeof(file_location));
 	sprintf(file_location, "/tmp/ba_histo-%d", priv->ba_aid);
 
-	oldfs = get_fs();
-	set_fs(KERNEL_DS);
 	filp_bahisto = filp_open(file_location,
 				 O_RDWR | O_CREAT | O_TRUNC, 0);
 
 	if (IS_ERR(filp_bahisto)) {
-		set_fs(oldfs);
 		ret = -EIO;
 		goto err;
 	}
@@ -1401,8 +1393,8 @@ static ssize_t mwl_debugfs_ba_hist_read(struct file *file, char __user *ubuf,
 
 			/* Buffer is full. Write to file and reset buf */
 			if ((strlen(buff) + 36) >= 500) {
-				vfs_write(filp_bahisto, buff, strlen(buff),
-					  &filp_bahisto->f_pos);
+				kernel_write(filp_bahisto, buff, strlen(buff),
+					     &filp_bahisto->f_pos);
 				mdelay(2);
 				memset(buff, 0, sizeof(buff));
 				data_p = buff;
@@ -1426,8 +1418,8 @@ static ssize_t mwl_debugfs_ba_hist_read(struct file *file, char __user *ubuf,
 				data_p += sprintf(data_p, "%8d\n", nobaflag);
 		}
 
-		vfs_write(filp_bahisto, buff, strlen(buff),
-			  &filp_bahisto->f_pos);
+		kernel_write(filp_bahisto, buff, strlen(buff),
+			     &filp_bahisto->f_pos);
 		len += scnprintf(p + len, size - len,
 				 "hole: %d, expect: %d, bmap0: %d, noba: %d\n",
 				 baholecnt, baexpcnt, bmap0cnt, nobacnt);
@@ -1440,7 +1432,6 @@ static ssize_t mwl_debugfs_ba_hist_read(struct file *file, char __user *ubuf,
 				 priv->ba_aid);
 
 	filp_close(filp_bahisto, current->files);
-	set_fs(oldfs);
 
 	ret = simple_read_from_buffer(ubuf, count, ppos, p, len);
 


### PR DESCRIPTION
In kernel 4.14 vfs_write() is not exported any more and drives should
use kernel_write() instead. Convert this driver to the other API as this
is available at least on kernel 4.4 and 4.9 also.

Fixes: #259

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>