### PR TITLE
fix delay_q free on deinit

### DIFF
--- a/hif/pcie/tx.c
+++ b/hif/pcie/tx.c
@@ -560,7 +560,7 @@ void pcie_tx_deinit(struct ieee80211_hw *hw)
 	int i;
 
 	for (i = 0; i < PCIE_DELAY_FREE_Q_LIMIT; i++)
-		if (!pcie_priv->delay_q[i])
+		if (pcie_priv->delay_q[i])
 			dev_kfree_skb_any(pcie_priv->delay_q[i]);
 
 	pcie_tx_ring_cleanup(priv);


### PR DESCRIPTION
Inverted test, always calling dev_kfree_skb_any() with a NULL argument.

The test could also be removed since it is redundant, but the
condition is marked as "unlikely" in dev_kfree_skb_any() so keeping
it here might have some valu valuee

Fixes: b25631de6ec4 ("Fixed monitor mode crash problem for 88W8864.")
Signed-off-by: Bjørn Mork <bjorn@mork.no>