### PR TITLE
Add mcast_cts && wmmedcaap to debugfs

### DIFF
--- a/hif/fwcmd.c
+++ b/hif/fwcmd.c
@@ -3335,3 +3335,27 @@ void mwl_fwcmd_get_survey(struct ieee80211_hw *hw, int idx)
 	       sizeof(struct ieee80211_channel));
 	mwl_hif_get_survey(hw, survey_info);
 }
+
+int mwl_fwcmd_mcast_cts(struct ieee80211_hw *hw, u8 enable)
+{
+	struct mwl_priv *priv = hw->priv;
+	struct hostcmd_cmd_mcast_cts *pcmd;
+
+	pcmd = (struct hostcmd_cmd_mcast_cts *)&priv->pcmd_buf[0];
+
+	mutex_lock(&priv->fwcmd_mutex);
+
+	memset(pcmd, 0x00, sizeof(*pcmd));
+	pcmd->cmd_hdr.cmd = cpu_to_le16(HOSTCMD_CMD_MCAST_CTS);
+	pcmd->cmd_hdr.len = cpu_to_le16(sizeof(*pcmd));
+	pcmd->enable = enable;
+
+	if (mwl_hif_exec_cmd(priv->hw, HOSTCMD_CMD_MCAST_CTS)) {
+		mutex_unlock(&priv->fwcmd_mutex);
+		return -EIO;
+	}
+
+	mutex_unlock(&priv->fwcmd_mutex);
+
+	return 0;
+}

--- a/hif/fwcmd.h
+++ b/hif/fwcmd.h
@@ -266,4 +266,6 @@ int mwl_fwcmd_core_dump_diag_mode(struct ieee80211_hw *hw, u16 status);
 
 void mwl_fwcmd_get_survey(struct ieee80211_hw *hw, int idx);
 
+int mwl_fwcmd_mcast_cts(struct ieee80211_hw *hw, u8 enable);
+
 #endif /* _FWCMD_H_ */

--- a/hif/hif-ops.h
+++ b/hif/hif-ops.h
@@ -284,4 +284,14 @@ static inline void mwl_hif_process_account(struct ieee80211_hw *hw)
 	if (priv->hif.ops->process_account)
 		priv->hif.ops->process_account(hw);
 }
+
+static inline int mwl_hif_mcast_cts(struct ieee80211_hw *hw, bool enable)
+{
+	struct mwl_priv *priv = hw->priv;
+
+	if (priv->hif.ops->mcast_cts)
+		return priv->hif.ops->mcast_cts(hw, enable);
+	else
+		return -ENOTSUPP;
+}
 #endif /* _HIF_OPS_H_ */

--- a/hif/hostcmd.h
+++ b/hif/hostcmd.h
@@ -75,6 +75,7 @@
 #define HOSTCMD_CMD_QUIET_MODE                  0x1201
 #define HOSTCMD_CMD_CORE_DUMP_DIAG_MODE         0x1202
 #define HOSTCMD_CMD_GET_FW_CORE_DUMP            0x1203
+#define HOSTCMD_CMD_MCAST_CTS                   0x4001
 
 /* Define general result code for each command */
 #define HOSTCMD_RESULT_OK                       0x0000
@@ -519,6 +520,12 @@ struct hostcmd_cmd_bss_start {
 	struct hostcmd_header cmd_hdr;
 	__le32 enable;                  /* FALSE: Disable or TRUE: Enable */
 	u8 amsdu;
+} __packed;
+
+/* HOSTCMD_CMD_MCAST_CTS */
+struct hostcmd_cmd_mcast_cts {
+	struct hostcmd_header cmd_hdr;
+	u8 enable;            /* 1:enable, 0:disable */
 } __packed;
 
 /* HOSTCMD_CMD_AP_BEACON */

--- a/hif/pcie/pcie.c
+++ b/hif/pcie/pcie.c
@@ -594,6 +594,11 @@ static int pcie_reg_access(struct ieee80211_hw *hw, bool write)
 	return ret;
 }
 
+static int pcie_mcast_cts(struct ieee80211_hw *hw, bool enable)
+{
+	return mwl_fwcmd_mcast_cts(hw, enable ? 1 : 0);
+}
+
 static const struct mwl_hif_ops pcie_hif_ops = {
 	.driver_name           = PCIE_DRV_NAME,
 	.driver_version        = PCIE_DRV_VERSION,
@@ -1400,6 +1405,7 @@ static const struct mwl_hif_ops pcie_hif_ops_ndp = {
 	.reg_access            = pcie_reg_access,
 	.set_sta_id            = pcie_set_sta_id,
 	.process_account       = pcie_process_account,
+	.mcast_cts             = pcie_mcast_cts,
 };
 
 static int pcie_probe(struct pci_dev *pdev, const struct pci_device_id *id)


### PR DESCRIPTION
write 1 to mcast_cts to enable, write 0 to disable.
after enable mcast_cts function, it will send cts to self before each
multicast packets, this can improve  multicast traffic performance.

write <tcq_num> <cw_min> <cw_max> <aifsn> <txop> to wmmedcaap to set
tcqN's EDCA parameter.
Example:
 echo 2 0x3 0x7 1 1 > wmmedcaap

Signed-off-by: Jinhua <zhangjh@marvell.com>