### PR TITLE
Use wiphy_to_ieee80211_hw() instead of wiphy_priv()

### DIFF
--- a/core.c
+++ b/core.c
@@ -264,7 +264,7 @@ static void mwl_reg_notifier(struct wiphy *wiphy,
 	int i, j, k;
 #endif
 
-	hw = (struct ieee80211_hw *)wiphy_priv(wiphy);
+	hw = wiphy_to_ieee80211_hw(wiphy);
 	priv = hw->priv;
 
 	if (priv->forbidden_setting) {


### PR DESCRIPTION
Observed a crash when built against a backported environment that
tracked to a NULL hw->priv.

https://github.com/torvalds/linux/commit/9a95371aa26e3cb9fb1340362912000088ff3c3e

> Note that mac802111 drivers should not use wiphy_priv() to try to  get their private driver structure as this is already used internally by mac80211