### PR TITLE
Fix non-backport use of nla_parse before 4.12.0

### DIFF
--- a/vendor_cmd.c
+++ b/vendor_cmd.c
@@ -17,6 +17,7 @@
 
 #include <net/mac80211.h>
 #include <net/netlink.h>
+#include <linux/version.h>
 
 #include "sysadpt.h"
 #include "core.h"
@@ -42,7 +43,11 @@ static int mwl_vendor_cmd_set_bf_type(struct wiphy *wiphy,
 		return -EPERM;
 
 	rc = nla_parse(tb, MWL_VENDOR_ATTR_MAX, data, data_len,
-		       mwl_vendor_attr_policy, NULL);
+		       mwl_vendor_attr_policy
+#if (defined(LINUX_BACKPORT) || (LINUX_VERSION_CODE >=KERNEL_VERSION(4,12,0)))
+               , NULL
+#endif
+               );
 	if (rc)
 		return rc;
 


### PR DESCRIPTION
Linux `v4.12-rc1` added a paremeter to `nla_parse()`.  This is "magically"
handled in backported environments but building older kernels without
backports fails.  This wasn't an issue till commit d9daa1d.

See also [v4.12-rc1 change](https://github.com/torvalds/linux/commit/fceb6435)