### PR TITLE
Timeout prevent

### DIFF
--- a/hif/pcie/pcie.c
+++ b/hif/pcie/pcie.c
@@ -33,7 +33,7 @@
 #define PCIE_DRV_DESC "Marvell Mac80211 Wireless PCIE Network Driver"
 #define PCIE_DEV_NAME "Marvell 802.11ac PCIE Adapter"
 
-#define MAX_WAIT_FW_COMPLETE_ITERATIONS 2000
+#define MAX_WAIT_FW_COMPLETE_ITERATIONS 10000
 #define CHECK_BA_TRAFFIC_TIME           300 /* msec */
 #define CHECK_TX_DONE_TIME              50  /* msec */
 


### PR DESCRIPTION
Increase MAX_WAIT_FW_COMPLETE_ITERATIONS to 10000 as before commit e5e0700 to prevent timeout as reported here: https://github.com/kaloz/mwlwifi/issues/308 (Original OP issue is probably not related though as his post preceeds commit e5e0700).