### PR TITLE
mwlwifi: add vendor cmd

### DIFF
--- a/vendor_cmd.c
+++ b/vendor_cmd.c
@@ -92,12 +92,14 @@ static const struct wiphy_vendor_command mwl_vendor_commands[] = {
 			  .subcmd = MWL_VENDOR_CMD_SET_BF_TYPE},
 		.flags = WIPHY_VENDOR_CMD_NEED_NETDEV,
 		.doit = mwl_vendor_cmd_set_bf_type,
+		.policy = mwl_vendor_attr_policy,
 	},
 	{
 		.info = { .vendor_id = MRVL_OUI,
 			  .subcmd = MWL_VENDOR_CMD_GET_BF_TYPE},
 		.flags = WIPHY_VENDOR_CMD_NEED_NETDEV,
 		.doit = mwl_vendor_cmd_get_bf_type,
+		.policy = mwl_vendor_attr_policy,
 	}
 };
 


### PR DESCRIPTION
Add vendor command policy which is enforced on mac80211 since kernel 5.3.