### PR TITLE
Properly detect Linux/Backports version

### DIFF
--- a/vendor_cmd.c
+++ b/vendor_cmd.c
@@ -92,7 +92,7 @@ static const struct wiphy_vendor_command mwl_vendor_commands[] = {
 			  .subcmd = MWL_VENDOR_CMD_SET_BF_TYPE},
 		.flags = WIPHY_VENDOR_CMD_NEED_NETDEV,
 		.doit = mwl_vendor_cmd_set_bf_type,
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0))
+#if (defined(LINUX_BACKPORT) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)))
 		.policy = mwl_vendor_attr_policy,
 #endif
 	},
@@ -101,7 +101,7 @@ static const struct wiphy_vendor_command mwl_vendor_commands[] = {
 			  .subcmd = MWL_VENDOR_CMD_GET_BF_TYPE},
 		.flags = WIPHY_VENDOR_CMD_NEED_NETDEV,
 		.doit = mwl_vendor_cmd_get_bf_type,
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0))
+#if (defined(LINUX_BACKPORT) || (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)))
 		.policy = mwl_vendor_attr_policy,
 #endif
 	}


### PR DESCRIPTION
Fixes ("747796b"): Fixed driver loading with kernel 5.3+

Signed-off-by: Jose Olivera <oliverajeo@gmail.com>