### PR TITLE
Fix driver loading with backports 5.3+

### DIFF
--- a/vendor_cmd.c
+++ b/vendor_cmd.c
@@ -92,7 +92,7 @@ static const struct wiphy_vendor_command mwl_vendor_commands[] = {
 			  .subcmd = MWL_VENDOR_CMD_SET_BF_TYPE},
 		.flags = WIPHY_VENDOR_CMD_NEED_NETDEV,
 		.doit = mwl_vendor_cmd_set_bf_type,
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0))
+#ifdef VENDOR_CMD_RAW_DATA
 		.policy = mwl_vendor_attr_policy,
 #endif
 	},
@@ -101,7 +101,7 @@ static const struct wiphy_vendor_command mwl_vendor_commands[] = {
 			  .subcmd = MWL_VENDOR_CMD_GET_BF_TYPE},
 		.flags = WIPHY_VENDOR_CMD_NEED_NETDEV,
 		.doit = mwl_vendor_cmd_get_bf_type,
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0))
+#ifdef VENDOR_CMD_RAW_DATA
 		.policy = mwl_vendor_attr_policy,
 #endif
 	}


### PR DESCRIPTION
Commit 747796b2f126 did not solve the issue that it crashes when an older kernel with a newer backport tries loading it, because it only detects kernel version.

As net/cfg80211.h in 5.3+ defines VENDOR_CMD_RAW_DATA, use it as a condition.