### PR TITLE
remove uaccess and pci-dma-compat calls for Kernel 5.18 and above

### DIFF
--- a/hif/pcie/8864/rx.c
+++ b/hif/pcie/8864/rx.c
@@ -107,11 +107,11 @@ static int pcie_rx_ring_init(struct mwl_priv *priv)
 			desc->prx_ring[i].rssi = 0x00;
 			desc->prx_ring[i].pkt_len =
 				cpu_to_le16(SYSADPT_MAX_AGGR_SIZE);
-			dma = pci_map_single(pcie_priv->pdev,
+			dma = dma_map_single(&(pcie_priv->pdev)->dev,
 					     rx_hndl->psk_buff->data,
 					     desc->rx_buf_size,
-					     PCI_DMA_FROMDEVICE);
-			if (pci_dma_mapping_error(pcie_priv->pdev, dma)) {
+					     DMA_FROM_DEVICE);
+			if (dma_mapping_error(&(pcie_priv->pdev)->dev, dma)) {
 				wiphy_err(priv->hw->wiphy,
 					  "failed to map pci memory!\n");
 				return -ENOMEM;
@@ -153,11 +153,11 @@ static void pcie_rx_ring_cleanup(struct mwl_priv *priv)
 			if (!rx_hndl->psk_buff)
 				continue;
 
-			pci_unmap_single(pcie_priv->pdev,
+			dma_unmap_single(&(pcie_priv->pdev)->dev,
 					 le32_to_cpu
 					 (rx_hndl->pdesc->pphys_buff_data),
 					 desc->rx_buf_size,
-					 PCI_DMA_FROMDEVICE);
+					 DMA_FROM_DEVICE);
 
 			dev_kfree_skb_any(rx_hndl->psk_buff);
 
@@ -332,11 +332,11 @@ static inline int pcie_rx_refill(struct mwl_priv *priv,
 	rx_hndl->pdesc->rssi = 0x00;
 	rx_hndl->pdesc->pkt_len = cpu_to_le16(desc->rx_buf_size);
 
-	dma = pci_map_single(pcie_priv->pdev,
+	dma = dma_map_single(&(pcie_priv->pdev)->dev,
 			     rx_hndl->psk_buff->data,
 			     desc->rx_buf_size,
-			     PCI_DMA_FROMDEVICE);
-	if (pci_dma_mapping_error(pcie_priv->pdev, dma)) {
+			     DMA_FROM_DEVICE);
+	if (dma_mapping_error(&(pcie_priv->pdev)->dev, dma)) {
 		dev_kfree_skb_any(rx_hndl->psk_buff);
 		wiphy_err(priv->hw->wiphy,
 			  "failed to map pci memory!\n");
@@ -410,10 +410,10 @@ void pcie_8864_rx_recv(unsigned long data)
 		prx_skb = curr_hndl->psk_buff;
 		if (!prx_skb)
 			goto out;
-		pci_unmap_single(pcie_priv->pdev,
+		dma_unmap_single(&(pcie_priv->pdev)->dev,
 				 le32_to_cpu(curr_hndl->pdesc->pphys_buff_data),
 				 desc->rx_buf_size,
-				 PCI_DMA_FROMDEVICE);
+				 DMA_FROM_DEVICE);
 		pkt_len = le16_to_cpu(curr_hndl->pdesc->pkt_len);
 
 		if (skb_tailroom(prx_skb) < pkt_len) {

--- a/hif/pcie/8864/tx.c
+++ b/hif/pcie/8864/tx.c
@@ -171,11 +171,11 @@ static void pcie_tx_ring_cleanup(struct mwl_priv *priv)
 					    desc->tx_hndl[i].psk_buff->data,
 					    le32_to_cpu(
 					    desc->ptx_ring[i].pkt_ptr));
-				pci_unmap_single(pcie_priv->pdev,
+				dma_unmap_single(&(pcie_priv->pdev)->dev,
 						 le32_to_cpu(
 						 desc->ptx_ring[i].pkt_ptr),
 						 desc->tx_hndl[i].psk_buff->len,
-						 PCI_DMA_TODEVICE);
+						 DMA_TO_DEVICE);
 				dev_kfree_skb_any(desc->tx_hndl[i].psk_buff);
 				desc->ptx_ring[i].status =
 					cpu_to_le32(EAGLE_TXD_STATUS_IDLE);
@@ -291,9 +291,9 @@ static inline void pcie_tx_skb(struct mwl_priv *priv, int desc_num,
 	tx_desc->type = tx_ctrl->type;
 	tx_desc->xmit_control = tx_ctrl->xmit_control;
 	tx_desc->sap_pkt_info = 0;
-	dma = pci_map_single(pcie_priv->pdev, tx_skb->data,
-			     tx_skb->len, PCI_DMA_TODEVICE);
-	if (pci_dma_mapping_error(pcie_priv->pdev, dma)) {
+	dma = dma_map_single(&(pcie_priv->pdev)->dev, tx_skb->data,
+			     tx_skb->len, DMA_TO_DEVICE);
+	if (dma_mapping_error(&(pcie_priv->pdev)->dev, dma)) {
 		dev_kfree_skb_any(tx_skb);
 		wiphy_err(priv->hw->wiphy,
 			  "failed to map pci memory!\n");
@@ -447,10 +447,10 @@ static void pcie_non_pfu_tx_done(struct mwl_priv *priv)
 		       (tx_desc->status & cpu_to_le32(EAGLE_TXD_STATUS_OK)) &&
 		       (!(tx_desc->status &
 		       cpu_to_le32(EAGLE_TXD_STATUS_FW_OWNED)))) {
-			pci_unmap_single(pcie_priv->pdev,
+			dma_unmap_single(&(pcie_priv->pdev)->dev,
 					 le32_to_cpu(tx_desc->pkt_ptr),
 					 le16_to_cpu(tx_desc->pkt_len),
-					 PCI_DMA_TODEVICE);
+					 DMA_TO_DEVICE);
 			done_skb = tx_hndl->psk_buff;
 			rate = le32_to_cpu(tx_desc->rate_info);
 			tx_desc->pkt_ptr = 0;

--- a/hif/pcie/8964/rx_ndp.c
+++ b/hif/pcie/8964/rx_ndp.c
@@ -86,11 +86,11 @@ static int pcie_rx_ring_init_ndp(struct mwl_priv *priv)
 			}
 			skb_reserve(psk_buff, MIN_BYTES_RX_HEADROOM);
 
-			dma = pci_map_single(pcie_priv->pdev,
+			dma = dma_map_single(&(pcie_priv->pdev)->dev,
 					     psk_buff->data,
 					     desc->rx_buf_size,
-					     PCI_DMA_FROMDEVICE);
-			if (pci_dma_mapping_error(pcie_priv->pdev, dma)) {
+					     DMA_FROM_DEVICE);
+			if (dma_mapping_error(&(pcie_priv->pdev)->dev, dma)) {
 				wiphy_err(priv->hw->wiphy,
 					  "failed to map pci memory!\n");
 				return -ENOMEM;
@@ -120,11 +120,11 @@ static void pcie_rx_ring_cleanup_ndp(struct mwl_priv *priv)
 	if (desc->prx_ring) {
 		for (i = 0; i < MAX_NUM_RX_DESC; i++) {
 			if (desc->rx_vbuflist[i]) {
-				pci_unmap_single(pcie_priv->pdev,
+				dma_unmap_single(&(pcie_priv->pdev)->dev,
 						 le32_to_cpu(
 						 desc->prx_ring[i].data),
 						 desc->rx_buf_size,
-						 PCI_DMA_FROMDEVICE);
+						 DMA_FROM_DEVICE);
 				desc->rx_vbuflist[i] = NULL;
 			}
 		}
@@ -411,11 +411,11 @@ static inline int pcie_rx_refill_ndp(struct mwl_priv *priv, u32 buf_idx)
 		return -ENOMEM;
 	skb_reserve(psk_buff, MIN_BYTES_RX_HEADROOM);
 
-	dma = pci_map_single(pcie_priv->pdev,
+	dma = dma_map_single(&(pcie_priv->pdev)->dev,
 			     psk_buff->data,
 			     desc->rx_buf_size,
-			     PCI_DMA_FROMDEVICE);
-	if (pci_dma_mapping_error(pcie_priv->pdev, dma)) {
+			     DMA_FROM_DEVICE);
+	if (dma_mapping_error(&(pcie_priv->pdev)->dev, dma)) {
 		wiphy_err(priv->hw->wiphy,
 			  "refill: failed to map pci memory!\n");
 		return -ENOMEM;
@@ -520,10 +520,10 @@ recheck:
 			break;
 		}
 
-		pci_unmap_single(pcie_priv->pdev,
+		dma_unmap_single(&(pcie_priv->pdev)->dev,
 				 le32_to_cpu(prx_desc->data),
 				 desc->rx_buf_size,
-				 PCI_DMA_FROMDEVICE);
+				 DMA_FROM_DEVICE);
 
 		bad_mic = false;
 		ctrl = le32_to_cpu(prx_ring_done->ctrl);

--- a/hif/pcie/8964/tx_ndp.c
+++ b/hif/pcie/8964/tx_ndp.c
@@ -132,10 +132,10 @@ static void pcie_tx_ring_cleanup_ndp(struct mwl_priv *priv)
 	for (i = 0; i < MAX_TX_RING_SEND_SIZE; i++) {
 		tx_skb = desc->tx_vbuflist[i];
 		if (tx_skb) {
-			pci_unmap_single(pcie_priv->pdev,
+			dma_unmap_single(&(pcie_priv->pdev)->dev,
 					 desc->pphys_tx_buflist[i],
 					 tx_skb->len,
-					 PCI_DMA_TODEVICE);
+					 DMA_TO_DEVICE);
 			dev_kfree_skb_any(tx_skb);
 			desc->pphys_tx_buflist[i] = 0;
 			desc->tx_vbuflist[i] = NULL;
@@ -267,9 +267,9 @@ static inline int pcie_tx_skb_ndp(struct mwl_priv *priv,
 			(TXRING_CTRL_TAG_MGMT << TXRING_CTRL_TAG_SHIFT));
 	}
 
-	dma = pci_map_single(pcie_priv->pdev, tx_skb->data,
-			     tx_skb->len, PCI_DMA_TODEVICE);
-	if (pci_dma_mapping_error(pcie_priv->pdev, dma)) {
+	dma = dma_map_single(&(pcie_priv->pdev)->dev, tx_skb->data,
+			     tx_skb->len, DMA_TO_DEVICE);
+	if (dma_mapping_error(&(pcie_priv->pdev)->dev, dma)) {
 		dev_kfree_skb_any(tx_skb);
 		wiphy_err(priv->hw->wiphy,
 			  "failed to map pci memory!\n");
@@ -451,10 +451,10 @@ void pcie_tx_done_ndp(struct ieee80211_hw *hw)
 				  "buffer is NULL for tx done ring\n");
 			break;
 		}
-		pci_unmap_single(pcie_priv->pdev,
+		dma_unmap_single(&(pcie_priv->pdev)->dev,
 				 desc->pphys_tx_buflist[index],
 				 skb->len,
-				 PCI_DMA_TODEVICE);
+				 DMA_TO_DEVICE);
 		desc->pphys_tx_buflist[index] = 0;
 		desc->tx_vbuflist[index] = NULL;
 

--- a/hif/pcie/8997/rx.c
+++ b/hif/pcie/8997/rx.c
@@ -107,11 +107,11 @@ static int pcie_rx_ring_init(struct mwl_priv *priv)
 			desc->prx_ring[i].rssi = 0x00;
 			desc->prx_ring[i].pkt_len =
 				cpu_to_le16(SYSADPT_MAX_AGGR_SIZE);
-			dma = pci_map_single(pcie_priv->pdev,
+			dma = dma_map_single(&(pcie_priv->pdev)->dev,
 					     rx_hndl->psk_buff->data,
 					     desc->rx_buf_size,
-					     PCI_DMA_FROMDEVICE);
-			if (pci_dma_mapping_error(pcie_priv->pdev, dma)) {
+                         DMA_FROM_DEVICE);
+			if (dma_mapping_error(&(pcie_priv->pdev)->dev, dma)) {
 				wiphy_err(priv->hw->wiphy,
 					  "failed to map pci memory!\n");
 				return -ENOMEM;
@@ -153,11 +153,11 @@ static void pcie_rx_ring_cleanup(struct mwl_priv *priv)
 			if (!rx_hndl->psk_buff)
 				continue;
 
-			pci_unmap_single(pcie_priv->pdev,
+			dma_unmap_single(&(pcie_priv->pdev)->dev,
 					 le32_to_cpu
 					 (rx_hndl->pdesc->pphys_buff_data),
 					 desc->rx_buf_size,
-					 PCI_DMA_FROMDEVICE);
+					 DMA_FROM_DEVICE);
 
 			dev_kfree_skb_any(rx_hndl->psk_buff);
 
@@ -332,11 +332,11 @@ static inline int pcie_rx_refill(struct mwl_priv *priv,
 	rx_hndl->pdesc->rssi = 0x00;
 	rx_hndl->pdesc->pkt_len = cpu_to_le16(desc->rx_buf_size);
 
-	dma = pci_map_single(pcie_priv->pdev,
+	dma = dma_map_single(&(pcie_priv->pdev)->dev,
 			     rx_hndl->psk_buff->data,
 			     desc->rx_buf_size,
-			     PCI_DMA_FROMDEVICE);
-	if (pci_dma_mapping_error(pcie_priv->pdev, dma)) {
+			     DMA_FROM_DEVICE);
+	if (dma_mapping_error(&(pcie_priv->pdev)->dev, dma)) {
 		dev_kfree_skb_any(rx_hndl->psk_buff);
 		wiphy_err(priv->hw->wiphy,
 			  "failed to map pci memory!\n");
@@ -410,10 +410,10 @@ void pcie_8997_rx_recv(unsigned long data)
 		prx_skb = curr_hndl->psk_buff;
 		if (!prx_skb)
 			goto out;
-		pci_unmap_single(pcie_priv->pdev,
+		dma_unmap_single(&(pcie_priv->pdev)->dev,
 				 le32_to_cpu(curr_hndl->pdesc->pphys_buff_data),
 				 desc->rx_buf_size,
-				 PCI_DMA_FROMDEVICE);
+				 DMA_FROM_DEVICE);
 		pkt_len = le16_to_cpu(curr_hndl->pdesc->pkt_len);
 
 		if (skb_tailroom(prx_skb) < pkt_len) {

--- a/hif/pcie/8997/tx.c
+++ b/hif/pcie/8997/tx.c
@@ -139,10 +139,10 @@ static void pcie_txbd_ring_delete(struct mwl_priv *priv)
 			skb = pcie_priv->tx_buf_list[num];
 			tx_desc = (struct pcie_tx_desc *)skb->data;
 
-			pci_unmap_single(pcie_priv->pdev,
+			dma_unmap_single(&(pcie_priv->pdev)->dev,
 					 le32_to_cpu(tx_desc->pkt_ptr),
 					 skb->len,
-					 PCI_DMA_TODEVICE);
+					 DMA_TO_DEVICE);
 			dev_kfree_skb_any(skb);
 		}
 		pcie_priv->tx_buf_list[num] = NULL;
@@ -222,9 +222,9 @@ static inline void pcie_tx_skb(struct mwl_priv *priv,
 	tx_desc->type = tx_ctrl->type;
 	tx_desc->xmit_control = tx_ctrl->xmit_control;
 	tx_desc->sap_pkt_info = 0;
-	dma = pci_map_single(pcie_priv->pdev, tx_skb->data,
-			     tx_skb->len, PCI_DMA_TODEVICE);
-	if (pci_dma_mapping_error(pcie_priv->pdev, dma)) {
+	dma = dma_map_single(&(pcie_priv->pdev)->dev, tx_skb->data,
+			     tx_skb->len, DMA_TO_DEVICE);
+	if (dma_mapping_error(&(pcie_priv->pdev)->dev, dma)) {
 		dev_kfree_skb_any(tx_skb);
 		wiphy_err(priv->hw->wiphy,
 			  "failed to map pci memory!\n");
@@ -401,10 +401,10 @@ static void pcie_pfu_tx_done(struct mwl_priv *priv)
 			pfu_dma = (struct pcie_pfu_dma_data *)done_skb->data;
 			tx_desc = &pfu_dma->tx_desc;
 			dma_data = &pfu_dma->dma_data;
-			pci_unmap_single(pcie_priv->pdev,
+			dma_unmap_single(&(pcie_priv->pdev)->dev,
 					 le32_to_cpu(data_buf->paddr),
 					 le16_to_cpu(data_buf->len),
-					 PCI_DMA_TODEVICE);
+					 DMA_TO_DEVICE);
 			tx_desc->pkt_ptr = 0;
 			tx_desc->pkt_len = 0;
 			tx_desc->status = cpu_to_le32(EAGLE_TXD_STATUS_IDLE);

--- a/hif/pcie/pcie.c
+++ b/hif/pcie/pcie.c
@@ -1700,7 +1700,7 @@ static int pcie_probe(struct pci_dev *pdev, const struct pci_device_id *id)
 		return rc;
 	}
 
-	rc = pci_set_dma_mask(pdev, DMA_BIT_MASK(32));
+	rc = dma_set_mask(&pdev->dev, DMA_BIT_MASK(32));
 	if (rc) {
 		pr_err("%s: 32-bit PCI DMA not supported\n",
 		       PCIE_DRV_NAME);

--- a/hif/pcie/pcie.c
+++ b/hif/pcie/pcie.c
@@ -1438,7 +1438,9 @@ static void pcie_bf_mimo_ctrl_decode(struct mwl_priv *priv,
 	const char filename[] = "/tmp/BF_MIMO_Ctrl_Field_Output.txt";
 	char str_buf[256];
 	char *buf = &str_buf[0];
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,18,0)
 	mm_segment_t oldfs;
+#endif
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)
 	oldfs = get_fs();
@@ -1446,7 +1448,7 @@ static void pcie_bf_mimo_ctrl_decode(struct mwl_priv *priv,
 #elif LINUX_VERSION_CODE < KERNEL_VERSION(5,10,0)
 	oldfs = get_fs();
 	set_fs(KERNEL_DS);
-#else
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(5,18,0)
 	oldfs = force_uaccess_begin();
 #endif
 
@@ -1470,7 +1472,7 @@ static void pcie_bf_mimo_ctrl_decode(struct mwl_priv *priv,
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5,10,0)
 	set_fs(oldfs);
-#else
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(5,18,0)
 	force_uaccess_end(oldfs);
 #endif
 }


### PR DESCRIPTION
Remove `force_uaccess_*` API usage for Kernel 5.18. The entire `get_fs` logic was removed [1] and the underlying read/write logic refactored, s.t. there should be no need to set the address boundaries anymore.

Also replace calls from _pci-dma-compat.h_ which have been removed in 5.18, too [2] with direct DMA calls, so that the module compiles against modern kernel versions. This should be backwards compatible until 2.6, as most of this stuff has always been convenience (unless the logic was patched in downstream projects)

Tested in OpenWRT with Kernel 5.15 and 6.1 on a Linksys WRT1900ACS router with 88W8864 chips.

[1] https://github.com/torvalds/linux/commit/967747bbc084b93b54e66f9047d342232314cd25

[2] https://github.com/torvalds/linux/commit/7968778914e53788a01c2dee2692cab157de9ac
