### PR TITLE
mwlwifi: fix PCIe DT node null pointer dereference

### DIFF
--- a/hif/pcie/pcie.c
+++ b/hif/pcie/pcie.c
@@ -685,7 +685,8 @@ static struct device_node *pcie_get_device_node(struct ieee80211_hw *hw)
 	struct device_node *dev_node;
 
 	dev_node = pci_bus_to_OF_node(pcie_priv->pdev->bus);
-	wiphy_info(priv->hw->wiphy, "device node: %s\n", dev_node->full_name);
+	if (dev_node)
+		wiphy_info(priv->hw->wiphy, "device node: %s\n", dev_node->full_name);
 
 	return dev_node;
 }


### PR DESCRIPTION
pci_bus_to_OF_node() used to get the PCI bus DT node returns node if found or NULL if none is found.

Since the return of pci_bus_to_OF_node() is not checked in the DT node name print it will cause a null pointer dereference and crash the kernel.

So first check whether the node is not NULL and then print.