### PR TITLE
Fix compilation warning with 64 bit system

### DIFF
--- a/debugfs.c
+++ b/debugfs.c
@@ -363,11 +363,16 @@ static ssize_t mwl_debugfs_info_read(struct file *file, char __user *ubuf,
 		len += scnprintf(p + len, size - len,
 			 "-----------------------=>  address| address|qlen|fw_desc_cnt\n");
 		spin_lock_irqsave(&pcie_priv->tx_desc_lock, flags);
-		len += scnprintf(p + len, size - len,
-				"wcb_base0   : %x => %8x|%8p|%4d|%d\n", get_hw_spec->wcb_base0, *((unsigned int *)le32_to_cpu(get_hw_spec->wcb_base0)),(void *)*((unsigned int *)le32_to_cpu(get_hw_spec->wcb_base0)),skb_queue_len(&pcie_priv->txq[0]),pcie_priv->fw_desc_cnt[0]);
+		len += scnprintf(p + len, size - len, "wcb_base0   : %x => %8x|%8p|%4u|%d\n",
+				 get_hw_spec->wcb_base0, le32_to_cpu(get_hw_spec->wcb_base0),
+				 &get_hw_spec->wcb_base0, skb_queue_len(&pcie_priv->txq[0]),
+				 pcie_priv->fw_desc_cnt[0]);
 		for(i = 0; i < SYSADPT_TOTAL_TX_QUEUES - 1; i++)
-			len += scnprintf(p + len, size - len,
-				"wcb_base[%2d]: %x => %8x|%8p|%4d|%d\n", i, get_hw_spec->wcb_base[i], *((unsigned int *)le32_to_cpu(get_hw_spec->wcb_base[i])),(void *)*((unsigned int *)le32_to_cpu(get_hw_spec->wcb_base[i])),skb_queue_len(&pcie_priv->txq[i + 1]),pcie_priv->fw_desc_cnt[i + 1]);
+			len += scnprintf(
+				p + len, size - len, "wcb_base[%2d]: %x => %8x|%8p|%4u|%d\n", i,
+				get_hw_spec->wcb_base[i], le32_to_cpu(get_hw_spec->wcb_base[i]),
+				&get_hw_spec->wcb_base[i], skb_queue_len(&pcie_priv->txq[i + 1]),
+				pcie_priv->fw_desc_cnt[i + 1]);
 		spin_unlock_irqrestore(&pcie_priv->tx_desc_lock, flags);
 	}
 
@@ -1341,10 +1346,8 @@ done:
 				 priv->reg_type, priv->reg_offset,
 				 priv->reg_value);
 	else
-		len += scnprintf(p + len, size - len,
-				 "error: %d(%u 0x%08x 0x%08x)\n",
-				 ret, priv->reg_type, priv->reg_offset,
-				 priv->reg_value);
+		len += scnprintf(p + len, size - len, "error: %zd(%u 0x%08x 0x%08x)\n", ret,
+				 priv->reg_type, priv->reg_offset, priv->reg_value);
 
 	ret = simple_read_from_buffer(ubuf, count, ppos, p, len);
 

--- a/hif/fwcmd.c
+++ b/hif/fwcmd.c
@@ -2624,7 +2624,7 @@ int mwl_fwcmd_encryption_set_key(struct ieee80211_hw *hw,
 		return -ENOTSUPP;
 	}
 
-	memcpy((void *)&pcmd->key_param.key, key->key, keymlen);
+	memcpy(&pcmd->key_param.key, key->key, keymlen);
 	pcmd->action_type = cpu_to_le32(action);
 
 	if (mwl_hif_exec_cmd(hw, HOSTCMD_CMD_UPDATE_ENCRYPTION)) {
@@ -3622,11 +3622,7 @@ int mwl_fwcmd_get_fw_core_dump(struct ieee80211_hw *hw,
 	core_dump->context = pcmd->cmd_data.coredump.context;
 	core_dump->size_kb = pcmd->cmd_data.coredump.size_kb;
 	core_dump->flags = pcmd->cmd_data.coredump.flags;
-	memcpy(buff,
-	       (const void *)((u32)pcmd +
-	       sizeof(struct hostcmd_cmd_get_fw_core_dump) -
-	       sizeof(struct hostcmd_cmd_get_fw_core_dump_)),
-	       MAX_CORE_DUMP_BUFFER);
+	memcpy(buff, pcmd->buffer, MAX_CORE_DUMP_BUFFER);
 
 	mutex_unlock(&priv->fwcmd_mutex);
 

--- a/hif/pcie/8964/tx_ndp.c
+++ b/hif/pcie/8964/tx_ndp.c
@@ -336,9 +336,8 @@ int pcie_tx_init_ndp(struct ieee80211_hw *hw)
 
 	if (sizeof(struct pcie_tx_ctrl_ndp) >
 	    sizeof(tx_info->driver_data)) {
-		wiphy_err(hw->wiphy, "driver data is not enough: %d (%d)\n",
-			  sizeof(struct pcie_tx_ctrl_ndp),
-			  sizeof(tx_info->driver_data));
+		wiphy_err(hw->wiphy, "driver data is not enough: %zu (%zu)\n",
+			  sizeof(struct pcie_tx_ctrl_ndp), sizeof(tx_info->driver_data));
 		return -ENOMEM;
 	}
 

--- a/hif/pcie/pcie.c
+++ b/hif/pcie/pcie.c
@@ -1466,8 +1466,7 @@ static void pcie_bf_mimo_ctrl_decode(struct mwl_priv *priv,
 			       &fp_data->f_pos);
 		filp_close(fp_data, current->files);
 	} else {
-		wiphy_err(priv->hw->wiphy, "Error opening %s! %x\n",
-			  filename, (unsigned int)fp_data);
+		wiphy_err(priv->hw->wiphy, "Error opening %s! %ld\n", filename, PTR_ERR(fp_data));
 	}
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5,10,0)


### PR DESCRIPTION
Use %zu and %zd where possible for ssize_t and size_t. Use PTR_ERR to correctly convert to negative error. Use universal pointer to support both 32 and 64bit systems.

Fix compilation warning:
/home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/mwlwifi-2023-04-29-6a436714/hif/fwcmd.c: In function 'mwl_fwcmd_get_fw_core_dump': /home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/mwlwifi-2023-04-29-6a436714/hif/fwcmd.c:3608:31: error: cast from pointer to integer of different size [-Werror=pointer-to-int-cast]
 3608 |                (const void *)((u32)pcmd +
      |                               ^
In file included from ./include/linux/device.h:15,
                 from /home/ansuel/openwrt-ansuel/openwrt/staging_dir/target-aarch64_cortex-a53_musl/usr/include/mac80211-backport/linux/device.h:3,
                 from ./include/linux/dma-mapping.h:7,
                 from /home/ansuel/openwrt-ansuel/openwrt/staging_dir/target-aarch64_cortex-a53_musl/usr/include/mac80211-backport/linux/dma-mapping.h:3,
                 from ./include/linux/skbuff.h:31,
                 from /home/ansuel/openwrt-ansuel/openwrt/staging_dir/target-aarch64_cortex-a53_musl/usr/include/mac80211-backport/linux/skbuff.h:3,
                 from ./include/linux/if_ether.h:19,
                 from /home/ansuel/openwrt-ansuel/openwrt/staging_dir/target-aarch64_cortex-a53_musl/usr/include/mac80211-backport/linux/if_ether.h:3,
                 from ./include/linux/etherdevice.h:20,
                 from /home/ansuel/openwrt-ansuel/openwrt/staging_dir/target-aarch64_cortex-a53_musl/usr/include/mac80211-backport/linux/etherdevice.h:3,
                 from /home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/mwlwifi-2023-04-29-6a436714/hif/pcie/tx_ndp.c:20:
/home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/mwlwifi-2023-04-29-6a436714/hif/pcie/tx_ndp.c: In function 'pcie_tx_init_ndp':
/home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/mwlwifi-2023-04-29-6a436714/hif/pcie/tx_ndp.c:338:38: error: format '%d' expects argument of type 'int', but argument 3 has type 'long unsigned int' [-Werror=format=]
  338 |                 wiphy_err(hw->wiphy, "driver data is not enough: %d (%d)\n",
      |                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./include/linux/dev_printk.h:110:30: note: in definition of macro 'dev_printk_index_wrap'
  110 |                 _p_func(dev, fmt, ##__VA_ARGS__);                       \
      |                              ^~~
./include/linux/dev_printk.h:144:56: note: in expansion of macro 'dev_fmt'
  144 |         dev_printk_index_wrap(_dev_err, KERN_ERR, dev, dev_fmt(fmt), ##__VA_ARGS__)
      |                                                        ^~~~~~~
/home/ansuel/openwrt-ansuel/openwrt/staging_dir/target-aarch64_cortex-a53_musl/usr/include/mac80211/net/cfg80211.h:8828:9: note: in expansion of macro 'dev_err'
 8828 |         dev_err(&(wiphy)->dev, format, ##args)
      |         ^~~~~~~
/home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/mwlwifi-2023-04-29-6a436714/hif/pcie/tx_ndp.c:338:17: note: in expansion of macro 'wiphy_err'
  338 |                 wiphy_err(hw->wiphy, "driver data is not enough: %d (%d)\n",
      |                 ^~~~~~~~~
/home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/mwlwifi-2023-04-29-6a436714/hif/pcie/tx_ndp.c:338:67: note: format string is defined here
  338 |                 wiphy_err(hw->wiphy, "driver data is not enough: %d (%d)\n",
      |                                                                  ~^
      |                                                                   |
      |                                                                   int
      |                                                                  %ld
/home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/mwlwifi-2023-04-29-6a436714/hif/pcie/tx_ndp.c:338:38: error: format '%d' expects argument of type 'int', but argument 4 has type 'long unsigned int' [-Werror=format=]
  338 |                 wiphy_err(hw->wiphy, "driver data is not enough: %d (%d)\n",
      |                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./include/linux/dev_printk.h:110:30: note: in definition of macro 'dev_printk_index_wrap'
  110 |                 _p_func(dev, fmt, ##__VA_ARGS__);                       \
      |                              ^~~
./include/linux/dev_printk.h:144:56: note: in expansion of macro 'dev_fmt'
  144 |         dev_printk_index_wrap(_dev_err, KERN_ERR, dev, dev_fmt(fmt), ##__VA_ARGS__)
      |                                                        ^~~~~~~
/home/ansuel/openwrt-ansuel/openwrt/staging_dir/target-aarch64_cortex-a53_musl/usr/include/mac80211/net/cfg80211.h:8828:9: note: in expansion of macro 'dev_err'
 8828 |         dev_err(&(wiphy)->dev, format, ##args)
      |         ^~~~~~~
/home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/mwlwifi-2023-04-29-6a436714/hif/pcie/tx_ndp.c:338:17: note: in expansion of macro 'wiphy_err'
  338 |                 wiphy_err(hw->wiphy, "driver data is not enough: %d (%d)\n",
      |                 ^~~~~~~~~
/home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/mwlwifi-2023-04-29-6a436714/hif/pcie/tx_ndp.c:338:71: note: format string is defined here
  338 |                 wiphy_err(hw->wiphy, "driver data is not enough: %d (%d)\n",
      |                                                                      ~^
      |                                                                       |
      |                                                                       int
      |                                                                      %ld
  CC [M]  /home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/mwlwifi-2023-04-29-6a436714/debugfs.o
In file included from ./include/linux/device.h:15,
                 from /home/ansuel/openwrt-ansuel/openwrt/staging_dir/target-aarch64_cortex-a53_musl/usr/include/mac80211-backport/linux/device.h:3,
                 from ./include/linux/dma-mapping.h:7,
                 from /home/ansuel/openwrt-ansuel/openwrt/staging_dir/target-aarch64_cortex-a53_musl/usr/include/mac80211-backport/linux/dma-mapping.h:3,
                 from ./include/linux/skbuff.h:31,
                 from /home/ansuel/openwrt-ansuel/openwrt/staging_dir/target-aarch64_cortex-a53_musl/usr/include/mac80211-backport/linux/skbuff.h:3,
                 from ./include/linux/if_ether.h:19,
                 from /home/ansuel/openwrt-ansuel/openwrt/staging_dir/target-aarch64_cortex-a53_musl/usr/include/mac80211-backport/linux/if_ether.h:3,
                 from ./include/linux/etherdevice.h:20,
                 from /home/ansuel/openwrt-ansuel/openwrt/staging_dir/target-aarch64_cortex-a53_musl/usr/include/mac80211-backport/linux/etherdevice.h:3,
                 from /home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/mwlwifi-2023-04-29-6a436714/hif/pcie/pcie.c:19:
/home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/mwlwifi-2023-04-29-6a436714/hif/pcie/pcie.c: In function 'pcie_bf_mimo_ctrl_decode':
/home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/mwlwifi-2023-04-29-6a436714/hif/pcie/pcie.c:1325:37: error: cast from pointer to integer of different size [-Werror=pointer-to-int-cast]
 1325 |                           filename, (unsigned int)fp_data);
      |                                     ^
./include/linux/dev_printk.h:110:37: note: in definition of macro 'dev_printk_index_wrap'
  110 |                 _p_func(dev, fmt, ##__VA_ARGS__);                       \
      |                                     ^~~~~~~~~~~
/home/ansuel/openwrt-ansuel/openwrt/staging_dir/target-aarch64_cortex-a53_musl/usr/include/mac80211/net/cfg80211.h:8828:9: note: in expansion of macro 'dev_err'
 8828 |         dev_err(&(wiphy)->dev, format, ##args)
      |         ^~~~~~~
/home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/mwlwifi-2023-04-29-6a436714/hif/pcie/pcie.c:1324:17: note: in expansion of macro 'wiphy_err'
 1324 |                 wiphy_err(priv->hw->wiphy, "Error opening %s! %x\n",
      |                 ^~~~~~~~~
cc1: all warnings being treated as errors
make[4]: *** [scripts/Makefile.build:289: /home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/mwlwifi-2023-04-29-6a436714/hif/pcie/tx_ndp.o] Error 1
make[4]: *** Waiting for unfinished jobs....
cc1: all warnings being treated as errors
make[4]: *** [scripts/Makefile.build:289: /home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/mwlwifi-2023-04-29-6a436714/hif/pcie/pcie.o] Error 1
/home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/mwlwifi-2023-04-29-6a436714/debugfs.c: In function 'mwl_debugfs_regrdwr_read':
/home/ansuel/openwrt-ansuel/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-ipq807x_generic/mwlwifi-2023-04-29-6a436714/debugfs.c:1335:43: error: format '%d' expects argument of type 'int', but argument 4 has type 'ssize_t' {aka 'long int'} [-Werror=format=]
 1335 |                                  "error: %d(%u 0x%08x 0x%08x)\n",
      |                                          ~^
      |                                           |
      |                                           int
      |                                          %ld
 1336 |                                  ret, priv->reg_type, priv->reg_offset,
      |                                  ~~~
      |                                  |
      |                                  ssize_t {aka long int}
cc1: all warnings being treated as errors