### PR TITLE
CCMP256, GCMP, GCMP256 support for W8964 chipsets + numerous fixes for all chipsets

### DIFF
--- a/core.c
+++ b/core.c
@@ -111,6 +111,20 @@ static const u32 cipher_suites[] = {
 	WLAN_CIPHER_SUITE_AES_CMAC,
 };
 
+static const u32 cipher_suites_8964[] = {
+		WLAN_CIPHER_SUITE_WEP40,
+		WLAN_CIPHER_SUITE_WEP104,
+		WLAN_CIPHER_SUITE_TKIP,
+		WLAN_CIPHER_SUITE_CCMP,
+		WLAN_CIPHER_SUITE_CCMP_256,
+		WLAN_CIPHER_SUITE_GCMP,
+		WLAN_CIPHER_SUITE_GCMP_256,
+		WLAN_CIPHER_SUITE_AES_CMAC,
+		WLAN_CIPHER_SUITE_BIP_CMAC_256,
+		WLAN_CIPHER_SUITE_BIP_GMAC_128,
+		WLAN_CIPHER_SUITE_BIP_GMAC_256,
+};
+
 static const struct ieee80211_iface_limit ap_if_limits[] = {
 	{ .max = SYSADPT_NUM_OF_AP, .types = BIT(NL80211_IFTYPE_AP) },
 #if defined(CPTCFG_MAC80211_MESH) || defined(CONFIG_MAC80211_MESH)
@@ -791,10 +805,13 @@ static int mwl_wl_init(struct mwl_priv *priv)
 	hw->wiphy->flags |= WIPHY_FLAG_HAS_CHANNEL_SWITCH;
 	hw->wiphy->flags |= WIPHY_FLAG_SUPPORTS_TDLS;
 	hw->wiphy->flags |= WIPHY_FLAG_AP_UAPSD;
-
-	hw->wiphy->cipher_suites = cipher_suites;
-	hw->wiphy->n_cipher_suites = ARRAY_SIZE(cipher_suites);
-
+	if (priv->chip_type == MWL8964) {
+		hw->wiphy->cipher_suites = cipher_suites_8964;
+		hw->wiphy->n_cipher_suites = ARRAY_SIZE(cipher_suites_8964);
+	} else {
+		hw->wiphy->cipher_suites = cipher_suites;
+		hw->wiphy->n_cipher_suites = ARRAY_SIZE(cipher_suites);
+	}
 	hw->vif_data_size = sizeof(struct mwl_vif);
 	hw->sta_data_size = sizeof(struct mwl_sta);
 

--- a/core.c
+++ b/core.c
@@ -467,7 +467,10 @@ static void mwl_set_ht_caps(struct mwl_priv *priv,
 	band->ht_cap.cap |= IEEE80211_HT_CAP_SM_PS;
 	band->ht_cap.cap |= IEEE80211_HT_CAP_SGI_20;
 	band->ht_cap.cap |= IEEE80211_HT_CAP_SGI_40;
-	band->ht_cap.cap |= IEEE80211_HT_CAP_DSSSCCK40;
+
+	if (band->band == NL80211_BAND_2GHZ) {
+		band->ht_cap.cap |= IEEE80211_HT_CAP_DSSSCCK40;
+	}
 
 	if ((priv->chip_type == MWL8997) &&
 	    (priv->antenna_tx != ANTENNA_TX_1)) {

--- a/core.h
+++ b/core.h
@@ -381,6 +381,14 @@ struct beacon_info {
 	u8 *ie_meshid_ptr;
 	u8 *ie_meshcfg_ptr;
 	u8 *ie_meshchsw_ptr;
+	u8 *ie_vendor_ptr;
+	u8 *ie_fast_bss_transition_ptr;
+	u8 *ie_neighbor_report_ptr;
+	u8 *ie_measure_request_ptr;
+	u8 *ie_measure_report_ptr;
+	u8 *ie_erp_info_ptr;
+	u8 *ie_mmie_ptr;
+
 	u8 ie_wmm_len;
 	u8 ie_wsc_len;
 	u8 ie_rsn_len;
@@ -392,6 +400,13 @@ struct beacon_info {
 	u8 ie_meshid_len;
 	u8 ie_meshcfg_len;
 	u8 ie_meshchsw_len;
+	u8 ie_vendor_len;
+	u8 ie_fast_bss_transition_len;
+	u8 ie_neighbor_report_len;
+	u8 ie_measure_request_len;
+	u8 ie_measure_report_len;
+	u8 ie_erp_info_len;
+	u8 ie_mmie_len;
 };
 
 struct mwl_vif {

--- a/hif/fwcmd.c
+++ b/hif/fwcmd.c
@@ -852,7 +852,28 @@ static int mwl_fwcmd_encryption_set_cmd_info(struct hostcmd_cmd_set_key *cmd,
 				      ENCR_KEY_FLAG_TSC_VALID);
 		break;
 	case WLAN_CIPHER_SUITE_CCMP:
-		cmd->key_param.key_type_id = cpu_to_le16(KEY_TYPE_ID_AES);
+		cmd->key_param.key_type_id = cpu_to_le16(KEY_TYPE_ID_CCMP);
+		cmd->key_param.key_info =
+			(key->flags & IEEE80211_KEY_FLAG_PAIRWISE) ?
+			cpu_to_le32(ENCR_KEY_FLAG_PAIRWISE) :
+			cpu_to_le32(ENCR_KEY_FLAG_TXGROUPKEY);
+		break;
+	case WLAN_CIPHER_SUITE_CCMP_256:
+		cmd->key_param.key_type_id = cpu_to_le16(KEY_TYPE_ID_CCMP_256);
+		cmd->key_param.key_info =
+			(key->flags & IEEE80211_KEY_FLAG_PAIRWISE) ?
+			cpu_to_le32(ENCR_KEY_FLAG_PAIRWISE) :
+			cpu_to_le32(ENCR_KEY_FLAG_TXGROUPKEY);
+		break;
+	case WLAN_CIPHER_SUITE_GCMP:
+		cmd->key_param.key_type_id = cpu_to_le16(KEY_TYPE_ID_GCMP);
+		cmd->key_param.key_info =
+			(key->flags & IEEE80211_KEY_FLAG_PAIRWISE) ?
+			cpu_to_le32(ENCR_KEY_FLAG_PAIRWISE) :
+			cpu_to_le32(ENCR_KEY_FLAG_TXGROUPKEY);
+		break;
+	case WLAN_CIPHER_SUITE_GCMP_256:
+		cmd->key_param.key_type_id = cpu_to_le16(KEY_TYPE_ID_GCMP_256);
 		cmd->key_param.key_info =
 			(key->flags & IEEE80211_KEY_FLAG_PAIRWISE) ?
 			cpu_to_le32(ENCR_KEY_FLAG_PAIRWISE) :
@@ -2618,6 +2639,9 @@ int mwl_fwcmd_encryption_set_key(struct ieee80211_hw *hw,
 		keymlen = MAX_ENCR_KEY_LENGTH + 2 * MIC_KEY_LENGTH;
 		break;
 	case WLAN_CIPHER_SUITE_CCMP:
+	case WLAN_CIPHER_SUITE_CCMP_256:
+	case WLAN_CIPHER_SUITE_GCMP:
+	case WLAN_CIPHER_SUITE_GCMP_256:
 		keymlen = key->keylen;
 		break;
 	default:

--- a/hif/fwcmd.c
+++ b/hif/fwcmd.c
@@ -550,7 +550,34 @@ static void mwl_fwcmd_parse_beacon(struct mwl_priv *priv,
 					beacon_info->ie_wsc_len = (elen + 2);
 					beacon_info->ie_wsc_ptr = (pos - 2);
 				}
-			}
+			} else {
+				beacon_info->ie_vendor_len = (elen + 2);
+				beacon_info->ie_vendor_ptr = (pos - 2);
+ 			}
+			break;
+		case WLAN_EID_NEIGHBOR_REPORT:
+			beacon_info->ie_neighbor_report_len = (elen + 2);
+			beacon_info->ie_neighbor_report_ptr = (pos - 2);
+			break;
+		case WLAN_EID_FAST_BSS_TRANSITION:
+			beacon_info->ie_fast_bss_transition_len = (elen + 2);
+			beacon_info->ie_fast_bss_transition_ptr = (pos - 2);
+			break;
+		case WLAN_EID_MEASURE_REQUEST:
+			beacon_info->ie_measure_request_len = (elen + 2);
+			beacon_info->ie_measure_request_ptr = (pos - 2);
+			break;
+		case WLAN_EID_MEASURE_REPORT:
+			beacon_info->ie_measure_report_len = (elen + 2);
+			beacon_info->ie_measure_report_ptr = (pos - 2);
+			break;
+		case WLAN_EID_ERP_INFO:
+			beacon_info->ie_erp_info_len = (elen + 2);
+			beacon_info->ie_erp_info_ptr = (pos - 2);
+			break;
+		case WLAN_EID_MMIE:
+			beacon_info->ie_mmie_len = (elen + 2);
+			beacon_info->ie_mmie_ptr = (pos - 2);
 			break;
 		default:
 			break;
@@ -617,6 +644,35 @@ static int mwl_fwcmd_set_ies(struct mwl_priv *priv, struct mwl_vif *mwl_vif)
 	memcpy(pcmd->ie_list_proprietary + ie_list_len_proprietary,
 	       beacon->ie_mde_ptr, beacon->ie_mde_len);
 	ie_list_len_proprietary += mwl_vif->beacon_info.ie_mde_len;
+
+	memcpy(pcmd->ie_list_proprietary + ie_list_len_proprietary,
+	       beacon->ie_vendor_ptr, beacon->ie_vendor_len);
+	ie_list_len_proprietary += mwl_vif->beacon_info.ie_vendor_len;
+
+
+	memcpy(pcmd->ie_list_proprietary + ie_list_len_proprietary,
+	       beacon->ie_neighbor_report_ptr, beacon->ie_neighbor_report_len);
+	ie_list_len_proprietary += mwl_vif->beacon_info.ie_neighbor_report_len;
+
+	memcpy(pcmd->ie_list_proprietary + ie_list_len_proprietary,
+	       beacon->ie_fast_bss_transition_ptr, beacon->ie_fast_bss_transition_len);
+	ie_list_len_proprietary += mwl_vif->beacon_info.ie_fast_bss_transition_len;
+
+	memcpy(pcmd->ie_list_proprietary + ie_list_len_proprietary,
+	       beacon->ie_measure_request_ptr, beacon->ie_measure_request_len);
+	ie_list_len_proprietary += mwl_vif->beacon_info.ie_measure_request_len;
+
+	memcpy(pcmd->ie_list_proprietary + ie_list_len_proprietary,
+	       beacon->ie_measure_report_ptr, beacon->ie_measure_report_len);
+	ie_list_len_proprietary += mwl_vif->beacon_info.ie_measure_report_len;
+
+	memcpy(pcmd->ie_list_proprietary + ie_list_len_proprietary,
+	       beacon->ie_erp_info_ptr, beacon->ie_erp_info_len);
+	ie_list_len_proprietary += mwl_vif->beacon_info.ie_erp_info_len;
+
+	memcpy(pcmd->ie_list_proprietary + ie_list_len_proprietary,
+	       beacon->ie_mmie_ptr, beacon->ie_mmie_len);
+	ie_list_len_proprietary += mwl_vif->beacon_info.ie_mmie_len;
 
 	pcmd->ie_list_len_proprietary = cpu_to_le16(ie_list_len_proprietary);
 

--- a/hif/fwcmd.h
+++ b/hif/fwcmd.h
@@ -55,12 +55,17 @@ enum {
 	WL_ANTENNATYPE_TX = 2,
 };
 
+
 enum encr_type {
 	ENCR_TYPE_WEP = 0,
 	ENCR_TYPE_DISABLE = 1,
 	ENCR_TYPE_TKIP = 4,
-	ENCR_TYPE_AES = 6,
+	ENCR_TYPE_CCMP = 6,
 	ENCR_TYPE_MIX = 7,
+	ENCR_TYPE_UNKNOWN = 8,
+	ENCR_TYPE_CCMP_256 = 9,
+	ENCR_TYPE_GCMP = 10,
+	ENCR_TYPE_GCMP_256 = 11,
 };
 
 char *mwl_fwcmd_get_cmd_string(unsigned short cmd);

--- a/hif/fwcmd.h
+++ b/hif/fwcmd.h
@@ -277,6 +277,9 @@ int mwl_fwcmd_get_fw_core_dump(struct ieee80211_hw *hw,
 
 int mwl_fwcmd_set_slot_time(struct ieee80211_hw *hw, bool short_slot);
 
+int mwl_fwcmd_set_slot_time_mwl8997(struct ieee80211_hw *hw, bool short_slot);
+
+
 int mwl_fwcmd_config_EDMACCtrl(struct ieee80211_hw *hw, int EDMAC_Ctrl);
 
 int mwl_fwcmd_set_txpwrlmt_cfg_data(struct ieee80211_hw *hw);
@@ -286,5 +289,9 @@ int mwl_fwcmd_get_txpwrlmt_cfg_data(struct ieee80211_hw *hw);
 int mwl_fwcmd_mcast_cts(struct ieee80211_hw *hw, u8 enable);
 
 void mwl_fwcmd_get_survey(struct ieee80211_hw *hw, int idx);
+
+int mwl_fwcmd_set_wds_mode(struct ieee80211_hw *hw, u32 wds_mode);
+int mwl_fwcmd_set_no_ack(struct ieee80211_hw *hw, u32 noack);
+int mwl_fwcmd_set_no_steer(struct ieee80211_hw *hw, u32 nosteer);
 
 #endif /* _FWCMD_H_ */

--- a/hif/hif.h
+++ b/hif/hif.h
@@ -30,9 +30,10 @@
 struct mwl_survey_info {
 	struct ieee80211_channel channel;
 	u32 filled;
-	u32 time_period;
-	u32 time_busy;
-	u32 time_tx;
+	u64 time_period;
+	u64 time_busy;
+	u64 time_tx;
+	u64 time_rx;
 	s8 noise;
 };
 

--- a/hif/hostcmd.h
+++ b/hif/hostcmd.h
@@ -28,6 +28,7 @@
 #define HOSTCMD_CMD_RF_REG_ACCESS               0x001b
 #define HOSTCMD_CMD_802_11_RADIO_CONTROL        0x001c
 #define HOSTCMD_CMD_MEM_ADDR_ACCESS             0x001d
+#define HOSTCMD_CMD_SET_TX_POWER_CLIENT_SCAN    0x001e
 #define HOSTCMD_CMD_802_11_TX_POWER             0x001f
 #define HOSTCMD_CMD_802_11_RF_ANTENNA           0x0020
 #define HOSTCMD_CMD_BROADCAST_SSID_ENABLE       0x0050 /* per-vif */
@@ -36,6 +37,7 @@
 #define HOSTCMD_CMD_SET_AID                     0x010d /* per-vif */
 #define HOSTCMD_CMD_SET_INFRA_MODE              0x010e /* per-vif */
 #define HOSTCMD_CMD_802_11_RTS_THSD             0x0113
+#define HOSTCMD_CMD_802_11_SLOT_TIME            0x0114
 #define HOSTCMD_CMD_SET_EDCA_PARAMS             0x0115
 #define HOSTCMD_CMD_802_11H_DETECT_RADAR        0x0120
 #define HOSTCMD_CMD_SET_WMM_MODE                0x0123
@@ -50,6 +52,7 @@
 #define HOSTCMD_CMD_DEL_MAC_ADDR                0x0206 /* per-vif */
 #define HOSTCMD_CMD_BSS_START                   0x1100 /* per-vif */
 #define HOSTCMD_CMD_AP_BEACON                   0x1101 /* per-vif */
+#define HOSTCMD_CMD_SET_WDS_MODE                0x1110 /* per-vif */
 #define HOSTCMD_CMD_SET_NEW_STN                 0x1111 /* per-vif */
 #define HOSTCMD_CMD_SET_APMODE                  0x1114
 #define HOSTCMD_CMD_SET_SWITCH_CHANNEL          0x1121
@@ -65,9 +68,12 @@
 #define HOSTCMD_CMD_DWDS_ENABLE                 0x1144
 #define HOSTCMD_CMD_FW_FLUSH_TIMER              0x1148
 #define HOSTCMD_CMD_SET_CDD                     0x1150
+#define HOSTCMD_CMD_SET_NO_ACK                  0x1152
+#define HOSTCMD_CMD_SET_NO_STEER                0x1153
 #define HOSTCMD_CMD_SET_BFTYPE                  0x1155
 #define HOSTCMD_CMD_CAU_REG_ACCESS              0x1157
 #define HOSTCMD_CMD_GET_TEMP                    0x1159
+#define HOSTCMD_CMD_SET_VHT_OPMODE              0x1168
 #define HOSTCMD_CMD_LED_CTRL                    0x1169
 #define HOSTCMD_CMD_GET_FW_REGION_CODE          0x116A
 #define HOSTCMD_CMD_GET_DEVICE_PWR_TBL          0x116B
@@ -75,9 +81,10 @@
 #define HOSTCMD_CMD_NEWDP_DMATHREAD_START       0x1189
 #define HOSTCMD_CMD_GET_FW_REGION_CODE_SC4      0x118A
 #define HOSTCMD_CMD_GET_DEVICE_PWR_TBL_SC4      0x118B
+#define HOSTCMD_CMD_SET_RTS_RETRY	        0x119A
 #define HOSTCMD_CMD_QUIET_MODE                  0x1201
 #define HOSTCMD_CMD_CORE_DUMP_DIAG_MODE         0x1202
-#define HOSTCMD_CMD_802_11_SLOT_TIME            0x1203
+#define HOSTCMD_CMD_802_11_SLOT_TIME_MWL8997    0x1203
 #define HOSTCMD_CMD_GET_FW_CORE_DUMP            0x1203
 #define HOSTCMD_CMD_EDMAC_CTRL                  0x1204
 #define HOSTCMD_CMD_TXPWRLMT_CFG                0x1211
@@ -1237,11 +1244,18 @@ struct hostcmd_cmd_get_fw_core_dump_ {
 } __packed;
 
 /* HOSTCMD_CMD_802_11_SLOT_TIME */
-struct hostcmd_cmd_802_11_slot_time {
+struct hostcmd_cmd_802_11_slot_time_mwl8997 {
 	struct hostcmd_header cmd_hdr;
 	__le16 action;
 	/* 0:long slot; 1:short slot */
 	__le16 short_slot;
+} __packed;
+
+struct hostcmd_cmd_802_11_slot_time {
+	struct hostcmd_header cmd_hdr;
+	__le16 action;
+	/* 0:long slot; 1:short slot */
+	u8 short_slot;
 } __packed;
 
 /* HOSTCMD_CMD_EDMAC_CTRL */
@@ -1290,6 +1304,14 @@ struct mwl_txpwrlmt_cfg_entry_hdr {
 struct hostcmd_cmd_mcast_cts {
 	struct hostcmd_header cmd_hdr;
 	u8 enable;            /* 1:enable, 0:disable */
+} __packed;
+
+/* HOSTCMD_CMD_SET_WDS_MODE */
+/* HOSTCMD_CMD_SET_NO_ACK */
+/* HOSTCMD_CMD_SET_NO_STEER */
+struct hostcmd_cmd_basic_cmd {
+	struct hostcmd_header cmd_hdr;
+	u32 value;
 } __packed;
 
 #endif /* _HOSTCMD_H_ */

--- a/hif/hostcmd.h
+++ b/hif/hostcmd.h
@@ -135,7 +135,11 @@
 
 #define KEY_TYPE_ID_WEP                         0x00
 #define KEY_TYPE_ID_TKIP                        0x01
-#define KEY_TYPE_ID_AES	                        0x02
+#define KEY_TYPE_ID_CCMP			0x02
+#define KEY_TYPE_ID_UNKNOWN			0x03
+#define KEY_TYPE_ID_CCMP_256			0x04
+#define KEY_TYPE_ID_GCMP			0x05
+#define KEY_TYPE_ID_GCMP_256			0x06
 
 /* Group key for RX only */
 #define ENCR_KEY_FLAG_RXGROUPKEY                0x00000002
@@ -846,10 +850,16 @@ struct aes_type_key {
 	u8 key_material[MAX_ENCR_KEY_LENGTH];
 } __packed;
 
+struct aes256_type_key {
+	/* AES Key material */
+	u8 key_material[MAX_ENCR_KEY_LENGTH * 2];
+} __packed;
+
 union mwl_key_type {
 	struct wep_type_key  wep_key;
 	struct tkip_type_key tkip_key;
 	struct aes_type_key  aes_key;
+	struct aes256_type_key  aes256_key;
 } __packed;
 
 struct key_param_set {

--- a/hif/pcie/dev.h
+++ b/hif/pcie/dev.h
@@ -51,6 +51,7 @@ enum {
 #define MCU_CCA_CNT               MAC_REG_ADDR(0x06A0)
 #define MCU_TXPE_CNT              MAC_REG_ADDR(0x06A4)
 #define MCU_LAST_READ             MAC_REG_ADDR(0x06A8)
+#define BBU_RXRDY_CNT_REG	  MAC_REG_ADDR(0x0860)
 
 /* Map to 0x80000000 (Bus control) on BAR0 */
 #define MACREG_REG_H2A_INTERRUPT_EVENTS      0x00000C18 /* (From host to ARM) */

--- a/hif/pcie/dev.h
+++ b/hif/pcie/dev.h
@@ -810,7 +810,12 @@ static inline void pcie_tx_encapsulate_frame(struct mwl_priv *priv,
 			data_pad = 12;
 			break;
 		case WLAN_CIPHER_SUITE_CCMP:
+		case WLAN_CIPHER_SUITE_GCMP:
 			data_pad = 8;
+			break;
+		case WLAN_CIPHER_SUITE_CCMP_256:
+		case WLAN_CIPHER_SUITE_GCMP_256:
+			data_pad = 16;
 			break;
 		}
 	}

--- a/hif/pcie/dev.h
+++ b/hif/pcie/dev.h
@@ -804,18 +804,20 @@ static inline void pcie_tx_encapsulate_frame(struct mwl_priv *priv,
 		switch (k_conf->cipher) {
 		case WLAN_CIPHER_SUITE_WEP40:
 		case WLAN_CIPHER_SUITE_WEP104:
-			data_pad = 4;
+			data_pad = IEEE80211_WEP_IV_LEN;
 			break;
 		case WLAN_CIPHER_SUITE_TKIP:
-			data_pad = 12;
+			data_pad = IEEE80211_TKIP_IV_LEN + IEEE80211_TKIP_ICV_LEN;
 			break;
 		case WLAN_CIPHER_SUITE_CCMP:
-		case WLAN_CIPHER_SUITE_GCMP:
-			data_pad = 8;
+			data_pad = IEEE80211_CCMP_MIC_LEN;
 			break;
 		case WLAN_CIPHER_SUITE_CCMP_256:
+			data_pad = IEEE80211_CCMP_MIC_LEN;
+			break;
+		case WLAN_CIPHER_SUITE_GCMP:
 		case WLAN_CIPHER_SUITE_GCMP_256:
-			data_pad = 16;
+			data_pad = IEEE80211_GCMP_MIC_LEN;
 			break;
 		}
 	}

--- a/hif/pcie/dev.h
+++ b/hif/pcie/dev.h
@@ -813,7 +813,7 @@ static inline void pcie_tx_encapsulate_frame(struct mwl_priv *priv,
 			data_pad = IEEE80211_CCMP_MIC_LEN;
 			break;
 		case WLAN_CIPHER_SUITE_CCMP_256:
-			data_pad = IEEE80211_CCMP_MIC_LEN;
+			data_pad = IEEE80211_CCMP_256_MIC_LEN;
 			break;
 		case WLAN_CIPHER_SUITE_GCMP:
 		case WLAN_CIPHER_SUITE_GCMP_256:

--- a/hif/pcie/pcie.c
+++ b/hif/pcie/pcie.c
@@ -682,10 +682,12 @@ static void pcie_get_survey(struct ieee80211_hw *hw,
 	survey_info->filled = SURVEY_INFO_TIME |
 			      SURVEY_INFO_TIME_BUSY |
 			      SURVEY_INFO_TIME_TX |
+			      SURVEY_INFO_TIME_RX |
 			      SURVEY_INFO_NOISE_DBM;
 	survey_info->time_period += pcie_read_mac_reg(pcie_priv, MCU_LAST_READ);
 	survey_info->time_busy += pcie_read_mac_reg(pcie_priv, MCU_CCA_CNT);
 	survey_info->time_tx += pcie_read_mac_reg(pcie_priv, MCU_TXPE_CNT);
+	survey_info->time_rx += pcie_read_mac_reg(pcie_priv, BBU_RXRDY_CNT_REG);
 	survey_info->noise = priv->noise;
 }
 

--- a/mac80211.c
+++ b/mac80211.c
@@ -372,10 +372,14 @@ static void mwl_mac80211_bss_info_changed_sta(struct ieee80211_hw *hw,
 {
 	struct mwl_priv *priv = hw->priv;
 
-	if ((changed & BSS_CHANGED_ERP_SLOT) && (priv->chip_type == MWL8997)) {
+	if (changed & BSS_CHANGED_ERP_SLOT) {
 		if (priv->use_short_slot != vif->bss_conf.use_short_slot) {
-			mwl_fwcmd_set_slot_time(hw,
-						vif->bss_conf.use_short_slot);
+			if (priv->chip_type == MWL8997)
+				mwl_fwcmd_set_slot_time_mwl8997(hw,
+							vif->bss_conf.use_short_slot);
+			else
+				mwl_fwcmd_set_slot_time(hw,
+							vif->bss_conf.use_short_slot);
 			priv->use_short_slot = vif->bss_conf.use_short_slot;
 		}
 	}
@@ -405,10 +409,14 @@ static void mwl_mac80211_bss_info_changed_ap(struct ieee80211_hw *hw,
 
 	mwl_vif = mwl_dev_get_vif(vif);
 
-	if ((changed & BSS_CHANGED_ERP_SLOT) && (priv->chip_type == MWL8997)) {
+	if (changed & BSS_CHANGED_ERP_SLOT) {
 		if (priv->use_short_slot != vif->bss_conf.use_short_slot) {
-			mwl_fwcmd_set_slot_time(hw,
-						vif->bss_conf.use_short_slot);
+			if (priv->chip_type == MWL8997)
+				mwl_fwcmd_set_slot_time_mwl8997(hw,
+							vif->bss_conf.use_short_slot);
+			else
+				mwl_fwcmd_set_slot_time(hw,
+							vif->bss_conf.use_short_slot);
 			priv->use_short_slot = vif->bss_conf.use_short_slot;
 		}
 	}

--- a/mac80211.c
+++ b/mac80211.c
@@ -523,19 +523,34 @@ static int mwl_mac80211_set_key(struct ieee80211_hw *hw,
 	addr = sta ? sta->addr : vif->addr;
 
 	if (cmd_param == SET_KEY) {
-		if ((key->cipher == WLAN_CIPHER_SUITE_WEP40) ||
-		    (key->cipher == WLAN_CIPHER_SUITE_WEP104)) {
+		switch (key->cipher) {
+		case WLAN_CIPHER_SUITE_WEP40:
+		case WLAN_CIPHER_SUITE_WEP104:
 			encr_type = ENCR_TYPE_WEP;
-		} else if (key->cipher == WLAN_CIPHER_SUITE_CCMP) {
-			encr_type = ENCR_TYPE_AES;
+			break;
+		case WLAN_CIPHER_SUITE_CCMP:
+			encr_type = ENCR_TYPE_CCMP;
 			if (priv->chip_type != MWL8964)
 				key->flags |= IEEE80211_KEY_FLAG_GENERATE_IV;
-		} else if (key->cipher == WLAN_CIPHER_SUITE_TKIP) {
-			if (priv->chip_type != MWL8964)
-				key->flags |= IEEE80211_KEY_FLAG_GENERATE_MMIC | IEEE80211_KEY_FLAG_GENERATE_IV;
+			break;
+		case WLAN_CIPHER_SUITE_CCMP_256:
+			encr_type = ENCR_TYPE_CCMP_256;
+			break;
+		case WLAN_CIPHER_SUITE_GCMP:
+			encr_type = ENCR_TYPE_GCMP;
+			break;
+		case WLAN_CIPHER_SUITE_GCMP_256:
+			encr_type = ENCR_TYPE_GCMP_256;
+			break;
+		case WLAN_CIPHER_SUITE_TKIP:
 			encr_type = ENCR_TYPE_TKIP;
-		} else {
+			if (priv->chip_type != MWL8964)
+				key->flags |= IEEE80211_KEY_FLAG_GENERATE_MMIC |
+					      IEEE80211_KEY_FLAG_GENERATE_IV;
+			break;
+		default:
 			encr_type = ENCR_TYPE_DISABLE;
+			break;
 		}
 
 		rc = mwl_fwcmd_update_encryption_enable(hw, vif, addr,

--- a/mac80211.c
+++ b/mac80211.c
@@ -772,9 +772,14 @@ static int mwl_mac80211_get_survey(struct ieee80211_hw *hw,
 
 	survey->channel = &survey_info->channel;
 	survey->filled |= survey_info->filled;
-	survey->time = survey_info->time_period / 1000;
-	survey->time_busy = survey_info->time_busy / 1000;
-	survey->time_tx = survey_info->time_tx / 1000;
+	survey->time = survey_info->time_period;
+	survey->time_busy = survey_info->time_busy;
+	survey->time_tx = survey_info->time_tx;
+	survey->time_rx = survey_info->time_rx;
+	do_div(survey->time, 1000);
+	do_div(survey->time_busy, 1000);
+	do_div(survey->time_tx, 1000);
+	do_div(survey->time_rx, 1000);
 	survey->noise = survey_info->noise;
 
 	return 0;

--- a/thermal.c
+++ b/thermal.c
@@ -84,9 +84,17 @@ static ssize_t mwl_thermal_show_temp(struct device *dev,
 	}
 
 	temperature = priv->temperature;
+	if (priv->chip_type == MWL8864) {
+		/* unit is in fahrenheit for this chipset */
+		temperature -= 32;
+		temperature *= 10;
+		temperature /= 18;
+		ret = snprintf(buf, PAGE_SIZE, "%d\n", temperature * 1000);
+	} else {
+		ret = snprintf(buf, PAGE_SIZE, "%d\n", temperature * 100);
+	}
 
 	/* display in millidegree celcius */
-	ret = snprintf(buf, PAGE_SIZE, "%d\n", temperature * 1000);
 out:
 	return ret;
 }
@@ -123,9 +131,6 @@ int mwl_thermal_register(struct mwl_priv *priv)
 	struct thermal_cooling_device *cdev;
 	struct device *hwmon_dev;
 	int ret;
-
-	if (priv->chip_type != MWL8897)
-		return 0;
 
 	cdev = thermal_cooling_device_register("mwlwifi_thermal", priv,
 					       &mwl_thermal_ops);


### PR DESCRIPTION
this pull requests does bring support for CCMP256, GCMP and GCMP256 hw cipher modes for W8964 (mainly used on WRT3200ACM/WRT32X devices)

apart from this it also enhances survey info with rx busy info and it also adds ie element parsing and broadcasting for 802.11k related info elements (measurement reports etc)

in addition it adds support for thermal sensors on W8864 and W8964. i dont know why it was disabled .maybe people thought the values reported where bogus. in fact the W8864 reports its values in  fahrenheid instead of celsius while W8964 reports it in celsius. the patch will convert the 8864 values to celcius for proper reporting

and last but not least slot time setting for 8864 / 8964 has been added.

sorry that i havent split these commits into separate pull requests. so take it as RFC for proper testing of the community